### PR TITLE
Landing page background image is not filled the complete width. I am solved that issue

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -148,7 +148,7 @@ body{
   height: 100vh;
   max-width: 100vw;
   background: var(--white) url("../media/Images/Background1.jpg") no-repeat;
-  background-size: 100rem;
+  background-size: cover;
 }
 .hero-left {
   position: relative;


### PR DESCRIPTION
**Before my change**
![Screenshot from 2021-10-03 10-55-27](https://user-images.githubusercontent.com/70310447/135741154-ab77fe7f-39a2-4bdd-bd50-718fb49e588c.png)

The landing page background image is not filled

**After my change**
![Screenshot from 2021-10-03 10-56-36](https://user-images.githubusercontent.com/70310447/135741192-29674bf0-ddb4-4503-855f-53fcfdacdf62.png)

The Landing page is now filled the complete width
