### PR TITLE
Closes #333 : The mentor discord link on benefits page was fixed

### DIFF
--- a/benefit.html
+++ b/benefit.html
@@ -189,7 +189,7 @@
           </div>
 
           <div class="mentor-profile">
-            <a href=" discordapp.com/users/758681549993541684">
+            <a href="https://discordapp.com/users/758681549993541684">
                       <i class="fab fa-discord"></i>Saurav Mukherjee#4599 </a>
           </div>
           


### PR DESCRIPTION
Closes #333 

**Issue**: The link to mentor's discord on the benefit page was giving 404 error.

**Cause**: The page was hyperlinked without https so it was redirecting as a local page at current directory.

**Fix**: added https header to it at line 192 in the benefits.html page.

**Screenshots**:

![image](https://user-images.githubusercontent.com/96640527/193415127-37f85321-d288-41e2-ba7f-38b095d789bc.png)

![image](https://user-images.githubusercontent.com/96640527/193415093-5cc1aecf-9b6f-4eb4-aef1-545b38ef9794.png)
