### PR TITLE
removed unnecessary spacing after Join Us Section on Hacktoberfest Page

### DIFF
--- a/hacktoberfest2022.html
+++ b/hacktoberfest2022.html
@@ -382,20 +382,9 @@
       </div>
     </section>
     <!-- Services Section End -->
-
-
-
   </div>
 
-
-
-
-
-  <br><br><br>
-  <br><br><br>
-  <br><br><br>
-
-
+  <br>
 
   <!---- Sponsors
     ==================================== -->


### PR DESCRIPTION
Fixes Issue #499 
Unnecessary spacing after Join Us Section on Hacktoberfest Page is removed.
![Screenshot (19)](https://user-images.githubusercontent.com/92395053/194061824-d6f98b5e-e685-4275-ad13-bcd2d5b0b3a8.png)
