### PR TITLE
fix for - the accordion for FAQs should show "-" as the right icon while opening, while closing it should again go back to "+"

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1858,6 +1858,12 @@ button.accordionFAQs i.slidedown.slide-top {
   float: right;
   margin-left: 5px;
 }
+.FAQs_section .active:after{
+    content: "\02796" !important;
+    font-size: 13px;
+    float: right;
+    margin-left: 5px;
+}
 
 /* ////FAQ section ends here//// */
 


### PR DESCRIPTION
<img width="1728" height="547" alt="image" src="https://github.com/user-attachments/assets/7cab035e-0cac-4a84-850f-2c4e302da192" />
